### PR TITLE
fix: orientation bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "release": "release-it",
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",
-    "bootstrap": "yarn example && yarn && yarn pods",
-    "postinstall": "bob build"
+    "bootstrap": "yarn example && yarn && yarn pods"
   },
   "keywords": [
     "react-native",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "release": "release-it",
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",
-    "bootstrap": "yarn example && yarn && yarn pods"
+    "bootstrap": "yarn example && yarn && yarn pods",
+    "postinstall": "bob build"
   },
   "keywords": [
     "react-native",

--- a/src/dots/ExpandingDot.tsx
+++ b/src/dots/ExpandingDot.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import {
-  View,
-  Dimensions,
   Animated,
   StyleSheet,
+  useWindowDimensions,
+  View,
   ViewStyle,
 } from 'react-native';
-
 export interface ExpandingDotProps {
   data: Array<Object>;
   scrollX: Animated.Value;
@@ -18,8 +17,6 @@ export interface ExpandingDotProps {
   activeDotColor?: string;
 }
 
-const { width } = Dimensions.get('screen');
-
 const ExpandingDot = ({
   scrollX,
   data,
@@ -30,6 +27,8 @@ const ExpandingDot = ({
   expandingDotWidth,
   activeDotColor,
 }: ExpandingDotProps) => {
+  const { width } = useWindowDimensions();
+
   const defaultProps = {
     inActiveDotColor: inActiveDotColor || '#000',
     inActiveDotOpacity: inActiveDotOpacity || 0.5,

--- a/src/dots/LiquidLike.tsx
+++ b/src/dots/LiquidLike.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import {
-  View,
   Animated,
-  Dimensions,
-  ViewStyle,
   StyleSheet,
+  useWindowDimensions,
+  View,
+  ViewStyle,
 } from 'react-native';
 import { Line, Svg } from 'react-native-svg';
-
 export interface LiquidLikeProps {
   data: Array<Object>;
   scrollX: Animated.Value;
@@ -26,7 +25,6 @@ export interface LiquidLikeProps {
 
 const AnimatedLine = Animated.createAnimatedComponent(Line);
 const AnimatedSvg = Animated.createAnimatedComponent(Svg);
-const { width } = Dimensions.get('screen');
 const LiquidLike = ({
   scrollX,
   data,
@@ -42,6 +40,8 @@ const LiquidLike = ({
   strokeWidth,
   bigHeadScale,
 }: LiquidLikeProps) => {
+  const { width } = useWindowDimensions();
+
   const defaultProps = {
     dotSize: dotSize || 12,
     marginHorizontal: marginHorizontal || 6,

--- a/src/dots/ScalingDot.tsx
+++ b/src/dots/ScalingDot.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import {
-  View,
-  Dimensions,
   Animated,
   StyleSheet,
+  useWindowDimensions,
+  View,
   ViewStyle,
 } from 'react-native';
-
 export interface ScalingDotProps {
   data: Array<Object>;
   scrollX: Animated.Value;
@@ -18,8 +17,6 @@ export interface ScalingDotProps {
   activeDotColor?: string;
 }
 
-const { width } = Dimensions.get('screen');
-
 const ScalingDot = ({
   scrollX,
   data,
@@ -30,6 +27,8 @@ const ScalingDot = ({
   activeDotScale,
   activeDotColor,
 }: ScalingDotProps) => {
+  const { width } = useWindowDimensions();
+
   const defaultProps = {
     inActiveDotColor: inActiveDotColor || '#347af0',
     activeDotColor: activeDotColor || '#347af0',

--- a/src/dots/SlidingBorder.tsx
+++ b/src/dots/SlidingBorder.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import {
-  View,
-  Dimensions,
-  StyleSheet,
   Animated,
+  StyleSheet,
+  useWindowDimensions,
+  View,
   ViewStyle,
 } from 'react-native';
-
 export interface SlidingBorderProps {
   data: Array<Object>;
   scrollX: Animated.Value;
@@ -18,7 +17,6 @@ export interface SlidingBorderProps {
   slidingIndicatorStyle?: ViewStyle;
 }
 
-const { width } = Dimensions.get('screen');
 const SlidingBorder = ({
   scrollX,
   data,
@@ -29,6 +27,8 @@ const SlidingBorder = ({
   slidingIndicatorStyle,
   borderPadding,
 }: SlidingBorderProps) => {
+  const { width } = useWindowDimensions();
+
   const defaultProps = {
     dotSize: dotSize || 24,
     borderPadding: borderPadding || -5,

--- a/src/dots/SlidingDot.tsx
+++ b/src/dots/SlidingDot.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import {
-  View,
-  Dimensions,
-  StyleSheet,
   Animated,
+  StyleSheet,
+  useWindowDimensions,
+  View,
   ViewStyle,
 } from 'react-native';
-
 export interface SlidingDotProps {
   data: Array<Object>;
   scrollX: Animated.Value;
@@ -18,7 +17,6 @@ export interface SlidingDotProps {
   marginHorizontal?: number;
 }
 
-const { width } = Dimensions.get('screen');
 const SlidingDot = ({
   scrollX,
   data,
@@ -28,6 +26,8 @@ const SlidingDot = ({
   slidingIndicatorStyle,
   marginHorizontal,
 }: SlidingDotProps) => {
+  const { width } = useWindowDimensions();
+
   const defaultProps = {
     dotSize: dotSize || 12,
     marginHorizontal: marginHorizontal || 3,


### PR DESCRIPTION
### Description

- This PR fixes an issue with the library when the device rotates from portrait to landscape or the other way around causing the library not to show the dots container properly.

### Problem

- The width that was used across the multiple components of this library was static, it didn't take into account changes of the width device. Also, there is a ticket created https://github.com/weahforsage/react-native-animated-pagination-dots/issues/3

### Fix

- In order to solve this issue my recommendation is to use this hook from the React Native core https://reactnative.dev/docs/usewindowdimensions , this will change the width automatically when screen rotates.