### PR TITLE
fixed marginHorizontal default value

### DIFF
--- a/src/dots/SlidingDot.tsx
+++ b/src/dots/SlidingDot.tsx
@@ -61,7 +61,7 @@ const SlidingDot = ({
           // eslint-disable-next-line react-native/no-inline-styles
           {
             position: 'absolute',
-            marginHorizontal: marginHorizontal,
+            marginHorizontal: defaultProps.marginHorizontal,
             transform: [{ translateX }],
           },
           slidingIndicatorStyle,


### PR DESCRIPTION
wrong `marginHorizontal` when the value isn't provided on *SlidingDot*. the fix is to use `defaultProps.marginHorizontal`, instead of just `marginHorizontal`.